### PR TITLE
Fix broken link in the README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,7 @@ The VRChat Client Simulator, or ClientSim for short, is a tool that enables you 
 - In your project, open the Unity Package Manager, click the + button and choose 'Add package from git URL...'.
   - Put in `https://github.com/vrchat/packages.git?path=/packages/com.vrchat.base#vcc`. Then wait as the package imports or press Ctrl+R to refresh if you have auto-refresh turned off.
   - Click the + button again and add this git url: `https://github.com/vrchat/packages.git?path=/packages/com.vrchat.worlds#vcc`
-  - Press the + button one last time and add this url: `https://github.com/vrchat-community/ClientSim.git?path=/ClientSim_UnityProject/Packages/com.vrchat.ClientSim#vcc`
+  - Press the + button one last time and add this url: `https://github.com/vrchat-community/ClientSim.git?path=/Packages/com.vrchat.ClientSim#vcc`
 
 ### Getting started
 


### PR DESCRIPTION
The last link in the installation was incorrect. This is the link that worked for me: https://github.com/vrchat-community/ClientSim.git?path=/Packages/com.vrchat.ClientSim#vcc