### PR TITLE
Add support for Algolia search

### DIFF
--- a/Tools/Docusaurus/docusaurus.config.js
+++ b/Tools/Docusaurus/docusaurus.config.js
@@ -124,6 +124,13 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
+      algolia: {
+        appId: 'NQHMNOH2YO',
+        apiKey: '292dfc501d73d6fa1352744ce4620735',
+        indexName: 'VRChat_Docs',
+        contextualSearch: true,
+        externalUrlRegex: 'https:\/\/(?!clientsim)' // Results that don't come from this site should redirect using their absolute URL, rather than redirecting relative to the current site
+      },
     }),
 };
 


### PR DESCRIPTION
Adds a search bar pointing to an Algolia index containing content from several VRChat creator doc sites, including https://clientsim.docs.vrchat.com/