### PR TITLE
Fix for issue #30: Canvas interaction without VRCUIShape

### DIFF
--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimBaseInput.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimBaseInput.cs
@@ -105,6 +105,12 @@ namespace VRC.SDK3.ClientSim
 
             // TODO properly pass in the camera provider instead of using this method.
             _playerCamera = VRC_UiShape.GetEventCamera?.Invoke();
+
+            foreach (var canvas in FindObjectsOfType<Canvas>())
+            {
+                if ((canvas.renderMode == RenderMode.WorldSpace) && (canvas.worldCamera == null))
+                    canvas.worldCamera = _playerCamera;
+            }
         }
 
         protected override void OnDestroy()


### PR DESCRIPTION
Fixes an issue where UI is not interactable when moved into Canvas that has no VRCUIShape script on Start.

In the test package provided [here](https://github.com/vrchat-community/ClientSim/issues/30), a Canvas gets childed to another canvas which has no child VRC_UiShape.

Raycasts then fail to work because the new parent has no Event Camera (which VRC_UiShapes add to their parents).
The new child does have a VRC_UiShape but it doesn't add an Event Camera due to already having been initialized.

This fix iterates all scene Canvases in Start, and sets the _playerCamera if their event camera is null, which is a broken state anyway. Question: do we know of any other systems relying on cameras, that this might mess with?