### PR TITLE
Fix broken Remove EditorOnly

### DIFF
--- a/Packages/com.vrchat.ClientSim/Runtime/ClientSimRuntimeLoader.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/ClientSimRuntimeLoader.cs
@@ -15,9 +15,13 @@ namespace VRC.SDK3.ClientSim
         private static ClientSimEventDispatcher _testEventDispatcherOverride;
 
         #region ClientSim Initialization
-
+        
+        // Dummy method to get the static initializer to be called early on.
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-        private static void OnBeforeSceneLoad()
+        static void OnBeforeSceneLoad() { }
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void OnAfterSceneLoad()
         {
             StartClientSim(GetSettings(), GetEventDispatcher());
         }


### PR DESCRIPTION
Remove "Editor Only" is not working correctly currently.
`GetRootGameObjects` seems to return an empty result before the scene is loaded.
By doing this, Removing GameObject processing is not working correctly.

CyanEmu is using `AfterSceneLoad`, but ClientSim is using `BeforeSceneLoad`.
So, I did use AfterSceneLoad like as CyanEmu.
The code is a copy from [here](https://github.com/vrchat-community/ClientSim/blob/dc12932c8334bfa53f7bcfe5adee163f93bb05af/Runtime/ClientSimMain.cs#L36) and [here](https://github.com/CyanLaser/CyanEmu/blob/master/CyanEmu/Scripts/CyanEmuMain.cs#L40).

I tested these changes in my own 2 projects.
It seems working correctly with `Remove EditorOnly` and other functions.
But I think need more tests, If dependent it's `BeforeSceneLoad`.