### PR TITLE
Removes simulation of VRC bug that prevented exiting stations

### DIFF
--- a/Packages/com.vrchat.ClientSim/Runtime/Helpers/ClientSimStationHelper.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/Helpers/ClientSimStationHelper.cs
@@ -118,11 +118,6 @@ namespace VRC.SDK3.ClientSim
                 _station.stationExitPlayerLocation = transform;
             }
             
-            // Warn about unusual setup.
-            if (!_station.seated && _station.PlayerMobility != VRCStation.Mobility.Mobile)
-            {
-                this.LogWarning($"Station has seated unchecked but is not mobile! This will immobilize the player, causing them to not be able to move on exit. Use VRCPlayerApi.Immobilize(false) to allow them to move again. {Tools.GetGameObjectPath(gameObject)}");
-            }
         }
 
         private void OnDestroy()

--- a/Packages/com.vrchat.ClientSim/Runtime/Player/ClientSimPlayerStationManager.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/Player/ClientSimPlayerStationManager.cs
@@ -153,13 +153,7 @@ namespace VRC.SDK3.ClientSim
 
             VRCPlayerApi player = _playerApiProvider.Player;
             
-            // If the station is set to seated, unset immobilize, allowing the player to move again.
-            // VRChatBug: Note that players are set immobile based on if the station is mobile and seated, but setting
-            // the player mobilized again is only if the station is not seated.
-            if (station.IsSeated())
-            {
-                player.Immobilize(false);
-            }
+            player.Immobilize(false);
             
             station.ExitStation(player);
             


### PR DESCRIPTION
ClientSim had code to simulate this old VRC bug, which will soon be unnecessary:
https://feedback.vrchat.com/vrchat-udon-closed-alpha-bugs/p/standing-stations-force-exit-locks-player-in-the-exit-location