### PR TITLE
Corrected player camera look x axis angle limits

### DIFF
--- a/Packages/com.vrchat.ClientSim/Runtime/Player/PlayerTracking/ClientSimDesktopTrackingRotator.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/Player/PlayerTracking/ClientSimDesktopTrackingRotator.cs
@@ -4,8 +4,8 @@ namespace VRC.SDK3.ClientSim.PlayerTracking
 {
     public class ClientSimDesktopTrackingRotator
     {
-        private const float MINIMUM_X_ANGLE = -80f;
-        private const float MAXIMUM_X_ANGLE = 70f;
+        private const float MINIMUM_X_ANGLE = -90f;
+        private const float MAXIMUM_X_ANGLE = 90f;
         private const float MINIMUM_Y_ANGLE = -90F;
         private const float MAXIMUM_Y_ANGLE = 90F;
         


### PR DESCRIPTION
When testing my worlds, I noticed that I am no longer able to look straight up or down at 90 degrees as I can in VRChat and with most FPS experiences. This is important not only because we should mimic what is possible in VRChat, but also because some experiences such as creating a parkour world require being able to check that you are standing at the edge of a cliff.

I can understand this limit initially being applied because it mimics the limits of how far human head can rotate when standing perfectly still, however in reality (even when playing VRChat in VR) when standing at a cliff we instinctually bend our backs to complete the 90 degree view, likewise we bend our knees if we need to look straight up. Therefor regardless of whether the user is playing in desktop or VR, it is both possible and practical to look 90 degrees if needed.

In the spirit of keeping ClientSim inline with the functionality of VRChat for both desktop, and VR, in addition to the usefulness in testing specific types of gameplay, I have modified the limits for the player camera rotation along the X axis from -80, 70, to -90, 90.