### PR TITLE
fix destroying focused udon objects

### DIFF
--- a/Packages/com.vrchat.ClientSim/Runtime/Helpers/ClientSimUdonHelper.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/Helpers/ClientSimUdonHelper.cs
@@ -102,6 +102,14 @@ namespace VRC.SDK3.ClientSim
         {
             // VRChatBug: Tooltips always ignore the tooltipPlacement transform and instead place the tooltip at the top
             // of the first collider on the object.
+            
+            //check if this object has already been destroyed, we can't just do a null check because that still throws a destroyed object error in unity
+            if (!Utilities.IsValid(this))
+            {
+                return Vector3.zero;
+            }
+
+
             return ClientSimTooltip.GetToolTipPosition(gameObject);
         }
 

--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimHighlightManager.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimHighlightManager.cs
@@ -76,6 +76,10 @@ namespace VRC.SDK3.ClientSim
 
         private List<Renderer> GatherRenderers(GameObject obj, bool findDisabled)
         {
+            if(obj == null)
+            {
+                return new List<Renderer>();
+            }
             List<Renderer> results = new List<Renderer>();
             foreach (var rend in obj.GetComponentsInChildren<Renderer>(findDisabled))
             {


### PR DESCRIPTION
null checks to fix clientsim exploding when you destroy gameobjects with udon