### PR TITLE
fix clientsim spawn bug

### DIFF
--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimMain.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimMain.cs
@@ -285,6 +285,7 @@ namespace VRC.SDK3.ClientSim
                 if (_player)
                 {
                     _player.isInstanceOwner = _settings.isInstanceOwner;
+                    _sceneManager.ResetSpawnOrder(); // Avoids any spawn offsets from pre-initialization of players
                     _player.EnablePlayer(_sceneManager.GetSpawnPoint(false));
                 }
             }

--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimSceneManager.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimSceneManager.cs
@@ -80,6 +80,11 @@ namespace VRC.SDK3.ClientSim
             return _descriptor.ObjectBehaviourAtRespawnHeight == VRC_SceneDescriptor.RespawnHeightBehaviour.Destroy;
         }
 
+        public void ResetSpawnOrder()
+        {
+            _spawnOrder = 0;
+        }
+        
         public Transform GetSpawnPoint(bool remote = false)
         {
             if (!HasSceneDescriptor())


### PR DESCRIPTION
I added a function to reset spawn order when initializing clientsim, which prevents preinitialization related spawning errors.
This is needed because we call into the same spawn function when initially loading in the localplayer, so sequential spawning offsets get messed up. (We load in the player at onBeforeSceneLoad, then clientsim respawns them at Start after everything is instantiated into the scene, so the sequential spawn counter gets ticked twice at startup)
There could be a better solution where we only call the spawn function once, but that's digging into levels of initialization-order-type spaghetti that I don't think make sense to tackle here.