### PR TITLE
downgrade "no scene descriptor" error to a non-blocking warning

### DIFF
--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimMain.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimMain.cs
@@ -186,7 +186,8 @@ namespace VRC.SDK3.ClientSim
             {
                 _instance = null;
                 Destroy(gameObject);
-                throw new ClientSimException("Cannot start ClientSim if there is no scene descriptor!");
+                Debug.LogWarning("Cannot start ClientSim if there is no scene descriptor!");
+                return;
             }
             
             _settings = settings;


### PR DESCRIPTION
old behaviour: trying to run a scene without a scene descriptor for testing, will result in ClientSim kicking you out of play mode.
We decided this was not desirable, following this issue: https://github.com/vrchat-community/ClientSim/issues/60
new behaviour: downgrade the error message to a warning and don't block users, instead disabling ClientSim when they enter play mode in an invalid scene.