### PR TITLE
Integrate CameraStacking into ClientSim

### DIFF
--- a/Packages/.gitignore
+++ b/Packages/.gitignore
@@ -1,3 +1,3 @@
 com.vrchat.*/
 !com.vrchat.core.*/
-!com.vrchat.ClientSim.*/
+!com.vrchat.ClientSim/

--- a/Packages/.gitignore
+++ b/Packages/.gitignore
@@ -1,2 +1,3 @@
 com.vrchat.*/
 !com.vrchat.core.*/
+!com.vrchat.ClientSim.*/

--- a/Packages/com.vrchat.ClientSim/Runtime/CameraStacking.meta
+++ b/Packages/com.vrchat.ClientSim/Runtime/CameraStacking.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7fd647d22852c4f4db99e7161481e563
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/Cameras.meta
+++ b/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/Cameras.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70f6d4c20b8065e408b6b1fe3223d9e7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/Cameras/Cam_UIMenu.asset
+++ b/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/Cameras/Cam_UIMenu.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8474ec07ef88d52458e79ca0f5240d96, type: 3}
+  m_Name: Cam_UIMenu
+  m_EditorClassIdentifier: 
+  CameraName: Cam_UIMenu
+  RenderLayer:
+    serializedVersion: 2
+    m_Bits: 4096
+  UseOcclusionCulling: 0

--- a/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/Cameras/Cam_UIMenu.asset
+++ b/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/Cameras/Cam_UIMenu.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8474ec07ef88d52458e79ca0f5240d96, type: 3}
   m_Name: Cam_UIMenu
   m_EditorClassIdentifier: 
-  CameraName: Cam_UIMenu
-  RenderLayer:
+  cameraName: Cam_UIMenu
+  renderLayer:
     serializedVersion: 2
     m_Bits: 4096
-  UseOcclusionCulling: 0
+  useOcclusionCulling: 0

--- a/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/Cameras/Cam_UIMenu.asset.meta
+++ b/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/Cameras/Cam_UIMenu.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d6ef66aee2eba604da699a98a28bba17
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedCamera.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedCamera.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace VRC.SDK3.ClientSim
+{
+    public class ClientSimStackedCamera : ScriptableObject
+    {
+        public string CameraName = "Generic Stacked Camera";
+        public LayerMask RenderLayer;
+        public bool UseOcclusionCulling = true;
+    }
+}

--- a/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedCamera.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedCamera.cs
@@ -1,15 +1,14 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.SceneManagement;
+﻿using UnityEngine;
 
 namespace VRC.SDK3.ClientSim
 {
     public class ClientSimStackedCamera : ScriptableObject
     {
-        public string CameraName = "Generic Stacked Camera";
-        public LayerMask RenderLayer;
-        public bool UseOcclusionCulling = true;
+        [SerializeField] private string cameraName = "Generic Stacked Camera";
+        [SerializeField] private LayerMask renderLayer;
+        [SerializeField] private bool useOcclusionCulling = true;
+        public string CameraName => cameraName;
+        public LayerMask RenderLayer => renderLayer;
+        public bool UseOcclusionCulling => useOcclusionCulling;
     }
 }

--- a/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedCamera.cs.meta
+++ b/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedCamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8474ec07ef88d52458e79ca0f5240d96
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedVRCameraSystem.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedVRCameraSystem.cs
@@ -45,17 +45,6 @@ namespace VRC.SDK3.ClientSim
             }
         }
      
-        /*void OnEnable()
-        {
-            #if !UNITY_ANDROID
-            if (MainSceneCamera != null)
-            {
-                if (!IsCameraStackingEnabled)
-                    CreateCameraStack();
-            }
-            #endif
-        }
-*/
         void OnDisable()
         {
             #if !UNITY_ANDROID
@@ -75,7 +64,6 @@ namespace VRC.SDK3.ClientSim
             {
                 CreateCameraStack();
                 IsInitialized = true;
-                FormattedLog("Camera Stack has been initialized.");
             }
             #else
             gameObject.SetActive(false);
@@ -121,8 +109,7 @@ namespace VRC.SDK3.ClientSim
 
             //Remove this cameras layers from the base camera
             MainSceneCamera.cullingMask = MainSceneCamera.cullingMask ^ CameraStack[index].RenderLayer;
-            FormattedLog($"Created Stacked Camera : {CameraStack[index].CameraName}");
-            
+
             // Set the ClientSim UI canvas to use this camera
             clientSimMenu.SetCanvasCamera(cam);
         }
@@ -135,15 +122,6 @@ namespace VRC.SDK3.ClientSim
             //Restore Layers from this camera to the main camera
             MainSceneCamera.cullingMask = MainSceneCamera.cullingMask | CameraStack[index].RenderLayer;
             Destroy(cam.gameObject);
-        }
-
-        private void FormattedLog(string s)
-        {
-#if UNITY_EDITOR
-            Debug.Log($"[<color=green>VRC Stacked Camera System</color>] {s}");
-#else
-            Debug.Log($"[VRC Stacked Camera System] {s}");
-#endif
         }
     }
 }

--- a/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedVRCameraSystem.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedVRCameraSystem.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.XR;
+using VRC.Core;
+using VRC.SDK3.ClientSim;
+
+namespace VRC.SDK3.ClientSim
+{
+    public class ClientSimStackedVRCameraSystem : MonoBehaviour
+    {
+        public ClientSimStackedCamera[] CameraStack;
+        [HideInInspector] public bool IsCameraStackingEnabled = false;
+        
+        private Camera MainSceneCamera;
+        private bool IsInitialized = false;
+        private bool IsReady = false;
+        private List<Camera> Cameras;
+        
+        private ClientSimMenu clientSimMenu;
+
+        public void Initialize(Camera playerCamera, ClientSimMenu menu)
+        {
+            MainSceneCamera = playerCamera;
+            clientSimMenu = menu;
+        }
+
+        public void Ready()
+        {
+            IsReady = true;
+        }
+        
+        void Update()
+        {
+            if(!IsReady) return;
+            if (!IsInitialized) { InitializeStackedSystem(); }
+            else
+            {
+                if (!Cameras[0].enabled)
+                {
+                    Debug.LogError("Stacked Cameras are not enabled.");
+                }
+            }
+        }
+     
+        /*void OnEnable()
+        {
+            #if !UNITY_ANDROID
+            if (MainSceneCamera != null)
+            {
+                if (!IsCameraStackingEnabled)
+                    CreateCameraStack();
+            }
+            #endif
+        }
+*/
+        void OnDisable()
+        {
+            #if !UNITY_ANDROID
+            if (MainSceneCamera != null)
+            {
+                if (IsCameraStackingEnabled)
+                    DestroyCameraStack();
+            }
+            #endif
+        }
+
+        public void InitializeStackedSystem()
+        {
+            #if !UNITY_ANDROID
+            Cameras = new List<Camera>();
+            if (MainSceneCamera != null)
+            {
+                CreateCameraStack();
+                IsInitialized = true;
+                FormattedLog("Camera Stack has been initialized.");
+            }
+            #else
+            gameObject.SetActive(false);
+            #endif
+        }
+
+        private void CreateCameraStack()
+        {
+            for (int i = 0; i < CameraStack.Length; i++)
+            {
+                AddCamera(i);
+            }
+            IsCameraStackingEnabled = true;
+        }
+
+        private void DestroyCameraStack()
+        {
+            for (int i = 0; i < Cameras.Count; i++)
+            {
+                DestroyCamera(i);
+            }
+            IsCameraStackingEnabled = false;
+        }
+
+        private void AddCamera(int index)
+        {
+            GameObject cameraObj = Instantiate(new GameObject(), MainSceneCamera.transform);
+            Camera cam = cameraObj.AddComponent<Camera>();
+            XRDevice.DisableAutoXRCameraTracking(cam, true);
+
+            cam.CopyFrom(MainSceneCamera); // Start by copying all the settings from the main camera
+            #if VRC_VR_STEAM // We only want this on SteamVR.
+            cameraObj.AddComponent<SteamVRCantedProjectionCullingFix>();
+            #endif
+            Cameras.Add(cam);
+
+            cameraObj.tag = "Untagged";
+            cameraObj.name = $"StackedCamera : {CameraStack[index].CameraName}";
+            cam.clearFlags = CameraClearFlags.Depth;
+            cam.depth = 100 - index;
+            cam.cullingMask = CameraStack[index].RenderLayer;
+            cam.useOcclusionCulling = CameraStack[index].UseOcclusionCulling;
+
+            //Remove this cameras layers from the base camera
+            MainSceneCamera.cullingMask = MainSceneCamera.cullingMask ^ CameraStack[index].RenderLayer;
+            FormattedLog($"Created Stacked Camera : {CameraStack[index].CameraName}");
+            
+            // Set the ClientSim UI canvas to use this camera
+            clientSimMenu.SetCanvasCamera(cam);
+        }
+
+        private void DestroyCamera(int index)
+        {
+            Camera cam = Cameras[index];
+            Cameras.RemoveAt(index);
+
+            //Restore Layers from this camera to the main camera
+            MainSceneCamera.cullingMask = MainSceneCamera.cullingMask | CameraStack[index].RenderLayer;
+            Destroy(cam.gameObject);
+        }
+
+        private void FormattedLog(string s)
+        {
+#if UNITY_EDITOR
+            Debug.Log($"[<color=green>VRC Stacked Camera System</color>] {s}");
+#else
+            Debug.Log($"[VRC Stacked Camera System] {s}");
+#endif
+        }
+    }
+}

--- a/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedVRCameraSystem.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedVRCameraSystem.cs
@@ -31,13 +31,6 @@ namespace VRC.SDK3.ClientSim
         {
             if(!_isReady) return;
             if (!_isInitialized) { InitializeStackedSystem(); }
-            else
-            {
-                if (!_cameras[0].enabled)
-                {
-                    Debug.LogError("Stacked Cameras are not enabled.");
-                }
-            }
         }
      
         void OnDisable()

--- a/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedVRCameraSystem.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedVRCameraSystem.cs
@@ -47,27 +47,21 @@ namespace VRC.SDK3.ClientSim
      
         void OnDisable()
         {
-            #if !UNITY_ANDROID
             if (MainSceneCamera != null)
             {
                 if (IsCameraStackingEnabled)
                     DestroyCameraStack();
             }
-            #endif
         }
 
         public void InitializeStackedSystem()
         {
-            #if !UNITY_ANDROID
             Cameras = new List<Camera>();
             if (MainSceneCamera != null)
             {
                 CreateCameraStack();
                 IsInitialized = true;
             }
-            #else
-            gameObject.SetActive(false);
-            #endif
         }
 
         private void CreateCameraStack()

--- a/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedVRCameraSystem.cs.meta
+++ b/Packages/com.vrchat.ClientSim/Runtime/CameraStacking/ClientSimStackedVRCameraSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1704c94808cb3c6479f3dc63042a956a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.ClientSim/Runtime/Resources/ClientSim/Prefabs/ClientSimSystem.prefab
+++ b/Packages/com.vrchat.ClientSim/Runtime/Resources/ClientSim/Prefabs/ClientSimSystem.prefab
@@ -31,6 +31,7 @@ Transform:
   - {fileID: 364660395058540043}
   - {fileID: 723530449456176699}
   - {fileID: 1719654290647426880}
+  - {fileID: 3140680102627537701}
   - {fileID: 7142198440650988715}
   - {fileID: 953007204702187934}
   - {fileID: 8577319452133450466}
@@ -59,8 +60,57 @@ MonoBehaviour:
   highlightManager: {fileID: 1762666294134124805}
   tooltipManager: {fileID: 6562708765974711755}
   playerSpawner: {fileID: 115519208876573542}
+  stackedCameraSystem: {fileID: 14227104928601329}
   proxyObjectPrefab: {fileID: 1211698646162851569, guid: 06d1c79a3adb363488e1418d1e7395d5,
     type: 3}
+--- !u!1 &6778504343277001007
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3140680102627537701}
+  - component: {fileID: 14227104928601329}
+  m_Layer: 10
+  m_Name: CameraStackingSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3140680102627537701
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6778504343277001007}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1880611392478369428}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &14227104928601329
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6778504343277001007}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1704c94808cb3c6479f3dc63042a956a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  clientSimPlayer: {fileID: 0}
+  MainSceneCamera: {fileID: 0}
+  CameraStack:
+  - {fileID: 11400000, guid: d6ef66aee2eba604da699a98a28bba17, type: 2}
+  IsCameraStackingEnabled: 0
 --- !u!1001 &1202083094369775472
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -71,7 +121,7 @@ PrefabInstance:
     - target: {fileID: 2132290821658042094, guid: ee584a366740d2a4dbebbd4270018e45,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 2132290821658042094, guid: ee584a366740d2a4dbebbd4270018e45,
         type: 3}
@@ -267,7 +317,7 @@ PrefabInstance:
     - target: {fileID: 8042128741019755946, guid: d761f4ad543663d41bebbbcb3cc81c94,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 8042128741019755946, guid: d761f4ad543663d41bebbbcb3cc81c94,
         type: 3}
@@ -359,7 +409,7 @@ PrefabInstance:
     - target: {fileID: 5108973792271252004, guid: 6f484702a206e8b47bff8ffd9d736602,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 5108973792271252004, guid: 6f484702a206e8b47bff8ffd9d736602,
         type: 3}
@@ -943,7 +993,7 @@ PrefabInstance:
     - target: {fileID: 1113984425070369126, guid: f6cffc14c9df5594e9aefe10ddcce4f0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 1113984425070369126, guid: f6cffc14c9df5594e9aefe10ddcce4f0,
         type: 3}

--- a/Packages/com.vrchat.ClientSim/Runtime/Resources/ClientSim/Prefabs/ClientSimSystem.prefab
+++ b/Packages/com.vrchat.ClientSim/Runtime/Resources/ClientSim/Prefabs/ClientSimSystem.prefab
@@ -106,11 +106,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1704c94808cb3c6479f3dc63042a956a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  clientSimPlayer: {fileID: 0}
-  MainSceneCamera: {fileID: 0}
-  CameraStack:
+  cameraStack:
   - {fileID: 11400000, guid: d6ef66aee2eba604da699a98a28bba17, type: 2}
-  IsCameraStackingEnabled: 0
 --- !u!1001 &1202083094369775472
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimMain.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimMain.cs
@@ -39,6 +39,8 @@ namespace VRC.SDK3.ClientSim
         private ClientSimTooltipManager tooltipManager;
         [SerializeField]
         private ClientSimPlayerSpawner playerSpawner;
+        [SerializeField]
+        private ClientSimStackedVRCameraSystem stackedCameraSystem;
         
         [SerializeField]
         private GameObject proxyObjectPrefab;
@@ -244,7 +246,8 @@ namespace VRC.SDK3.ClientSim
             Camera playerCamera = _player.GetCameraProvider().GetCamera();
             tooltipManager.Initialize(_settings, _player.GetTrackingProvider());
             highlightManager.Initialize(playerCamera);
-
+            stackedCameraSystem.Initialize(playerCamera, menu);
+            
             // Initialize SDK links after everything has been created and initialized.
             SetupSDKLinks();
         }
@@ -289,7 +292,7 @@ namespace VRC.SDK3.ClientSim
                     _player.EnablePlayer(_sceneManager.GetSpawnPoint(false));
                 }
             }
-            
+
             // Notify UdonManager that ClientSim is ready. This will then notify all registered UdonBehaviours that
             // they can begin running. Udon will initialize in the next frame in the next Update call.
             yield return _udonManager.OnClientSimReady();
@@ -301,6 +304,9 @@ namespace VRC.SDK3.ClientSim
             
             // Send event indicating ClientSim is initialized and ready.
             _eventDispatcher.SendEvent(new ClientSimReadyEvent());
+            
+            stackedCameraSystem.Ready();
+            
             this.Log("ClientSim Initialized");
         }
 

--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimMenu.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimMenu.cs
@@ -96,6 +96,11 @@ namespace VRC.SDK3.ClientSim
 
         private Canvas _menuCanvas;
 
+        public void SetCanvasCamera(Camera cam)
+        {
+            _menuCanvas.worldCamera = cam;
+        }
+        
         protected override void Awake()
         {
             base.Awake();


### PR DESCRIPTION
hooks camera stacking setup calls into clientsim initialization, order of execution is pretty important for this to work properly.
Camera Stacking prevents the clientsim menu from intersecting/being blocked by ingame menus. This change mirrors how we handle menus in the client.
This fixes issues like [https://github.com/vrchat-community/ClientSim/issues/51](https://github.com/vrchat-community/ClientSim/issues/51) and [https://github.com/vrchat-community/ClientSim/issues/58](https://github.com/vrchat-community/ClientSim/issues/58)