### PR TITLE
CRE-587 Add Language Method Stubs

### DIFF
--- a/Packages/com.vrchat.ClientSim/Editor/Windows/ClientSimSettingsWindow.cs
+++ b/Packages/com.vrchat.ClientSim/Editor/Windows/ClientSimSettingsWindow.cs
@@ -30,6 +30,7 @@ namespace VRC.SDK3.ClientSim.Editor
         private readonly GUIContent _showTooltipsGuiContent = new GUIContent("Show Tooltips", "If enabled, hovering over an interactable object or pickup will display a tooltip above the object.");
         private readonly GUIContent _invertMouseLookGuiContent = new GUIContent("Invert Mouse Look", "If enabled, moving the mouse up or down will invert the direction the player will look up and down.");
         private readonly GUIContent _playerHeightGuiContent = new GUIContent("Player Height", "How tall should the player be in meters. Default height is 1.9. Note that the player's collision capsule is 1.6 and never changes.");
+        private readonly GUIContent _currentLanguageGuiContent = new GUIContent("Current Language", "The language the player is currently using. Available languages include English, French, German, Italian, Japanese, Korean, and Spanish.");
         
         // Player settings
         private readonly GUIContent _playerButtonsFoldoutGuiContent = new GUIContent("Player Settings", "");
@@ -382,6 +383,7 @@ namespace VRC.SDK3.ClientSim.Editor
                 _settings.invertMouseLook = EditorGUILayout.Toggle(_invertMouseLookGuiContent, _settings.invertMouseLook);
                 _settings.playerHeight = EditorGUILayout.FloatField(_playerHeightGuiContent, _settings.playerHeight);
                 _settings.playerHeight = Mathf.Clamp(_settings.playerHeight, 0.2f, 80f); // TODO make consts for these.
+                _settings.currentLanguage = EditorGUILayout.TextField(_currentLanguageGuiContent, _settings.currentLanguage);
 
                 EditorGUI.EndDisabledGroup();
 

--- a/Packages/com.vrchat.ClientSim/Editor/Windows/ClientSimSettingsWindow.cs
+++ b/Packages/com.vrchat.ClientSim/Editor/Windows/ClientSimSettingsWindow.cs
@@ -31,6 +31,7 @@ namespace VRC.SDK3.ClientSim.Editor
         private readonly GUIContent _invertMouseLookGuiContent = new GUIContent("Invert Mouse Look", "If enabled, moving the mouse up or down will invert the direction the player will look up and down.");
         private readonly GUIContent _playerHeightGuiContent = new GUIContent("Player Height", "How tall should the player be in meters. Default height is 1.9. Note that the player's collision capsule is 1.6 and never changes.");
         private readonly GUIContent _currentLanguageGuiContent = new GUIContent("Current Language", "The language the player is currently using. Available languages include English, French, German, Italian, Japanese, Korean, and Spanish.");
+        private int selectedLanguageIndex;
         
         // Player settings
         private readonly GUIContent _playerButtonsFoldoutGuiContent = new GUIContent("Player Settings", "");
@@ -383,7 +384,8 @@ namespace VRC.SDK3.ClientSim.Editor
                 _settings.invertMouseLook = EditorGUILayout.Toggle(_invertMouseLookGuiContent, _settings.invertMouseLook);
                 _settings.playerHeight = EditorGUILayout.FloatField(_playerHeightGuiContent, _settings.playerHeight);
                 _settings.playerHeight = Mathf.Clamp(_settings.playerHeight, 0.2f, 80f); // TODO make consts for these.
-                _settings.currentLanguage = EditorGUILayout.TextField(_currentLanguageGuiContent, _settings.currentLanguage);
+                selectedLanguageIndex = EditorGUILayout.Popup(_currentLanguageGuiContent, selectedLanguageIndex, _settings.availableLanguages);
+                _settings.currentLanguage = _settings.availableLanguages[selectedLanguageIndex];
 
                 EditorGUI.EndDisabledGroup();
 

--- a/Packages/com.vrchat.ClientSim/Runtime/Settings/ClientSimSettings.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/Settings/ClientSimSettings.cs
@@ -46,6 +46,9 @@ namespace VRC.SDK3.ClientSim
         public bool showTooltips = true;
         public bool invertMouseLook = false;
         public float playerHeight = ClientSimTrackingProviderBase.AVATAR_HEIGHT; // Default avatar height is 1.9 units tall
+        public string currentLanguage = "English";
+        public readonly string[] availableLanguages =
+            { "English", "French", "German", "Italian", "Japanese", "Korean", "Spanish" };
 
 #if UNITY_EDITOR
         private static ClientSimSettings LoadSettings()

--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimMain.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimMain.cs
@@ -464,6 +464,9 @@ namespace VRC.SDK3.ClientSim
             VRCPlayerApi._SetVoiceDistanceFar += ClientSimPlayerManager.SetVoiceDistanceFar;
             VRCPlayerApi._SetVoiceDistanceNear += ClientSimPlayerManager.SetVoiceDistanceNear;
             VRCPlayerApi._SetVoiceGain += ClientSimPlayerManager.SetVoiceGain;
+
+            VRCPlayerApi._GetCurrentLanguage += ClientSimPlayerManager.GetCurrentLanguage;
+            VRCPlayerApi._GetAvailableLanguages += ClientSimPlayerManager.GetAvailableLanguages;
             
             VRC_SpatialAudioSource.Initialize += ClientSimSpatialAudioHelper.InitializeAudio;
 

--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimPlayerManager.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimPlayerManager.cs
@@ -673,6 +673,16 @@ namespace VRC.SDK3.ClientSim
         {
             player.GetClientSimPlayer().audioData.SetVoiceGain(value);
         }
+        
+        public static string GetCurrentLanguage()
+        {
+            return "English";
+        }
+        
+        public static string[] GetAvailableLanguages()
+        {
+            return new []{ "English", "Spanish", "German", "Klingon" };
+        }
 
         #endregion
     }

--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimPlayerManager.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimPlayerManager.cs
@@ -676,12 +676,12 @@ namespace VRC.SDK3.ClientSim
         
         public static string GetCurrentLanguage()
         {
-            return "English";
+            return ClientSimSettings.Instance.currentLanguage;
         }
         
         public static string[] GetAvailableLanguages()
         {
-            return new []{ "English", "Spanish", "German", "Klingon" };
+            return ClientSimSettings.Instance.availableLanguages;
         }
 
         #endregion


### PR DESCRIPTION
Follow up PR for https://github.com/vrchat/vrchat/pull/6877. Adds stubs for the new language methods to client sim so they can be tested in editor. The user can set the currently selected language in the client sim settings window.