### PR TITLE
Adds stub methods for AvatarScaling

### DIFF
--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimMain.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimMain.cs
@@ -450,6 +450,15 @@ namespace VRC.SDK3.ClientSim
             VRCPlayerApi._Respawn += ClientSimPlayerManager.Respawn;
             VRCPlayerApi._RespawnWithIndex += ClientSimPlayerManager.RespawnWithIndex;
             
+            VRCPlayerApi._GetManualAvatarScalingAllowed += ClientSimPlayerManager.GetManualAvatarScalingAllowed;
+            VRCPlayerApi._SetManualAvatarScalingAllowed += ClientSimPlayerManager.SetManualAvatarScalingAllowed;
+            VRCPlayerApi._GetAvatarEyeHeightMinimumAsMeters += ClientSimPlayerManager.GetAvatarEyeHeightMinimumAsMeters;
+            VRCPlayerApi._GetAvatarEyeHeightMaximumAsMeters += ClientSimPlayerManager.GetAvatarEyeHeightMaximumAsMeters;
+            VRCPlayerApi._SetAvatarEyeHeightMinimumByMeters += ClientSimPlayerManager.SetAvatarEyeHeightMinimumByMeters;
+            VRCPlayerApi._SetAvatarEyeHeightMaximumByMeters += ClientSimPlayerManager.SetAvatarEyeHeightMaximumByMeters;
+            VRCPlayerApi._GetAvatarEyeHeightAsMeters += ClientSimPlayerManager.GetAvatarEyeHeightAsMeters;
+            VRCPlayerApi._SetAvatarEyeHeightByMeters += ClientSimPlayerManager.SetAvatarEyeHeightByMeters;
+            VRCPlayerApi._SetAvatarEyeHeightByMultiplier += ClientSimPlayerManager.SetAvatarEyeHeightByMultiplier;
 
             VRCPlayerApi._CombatSetup += ClientSimCombatSystemHelper.CombatSetup;
             VRCPlayerApi._CombatSetMaxHitpoints += ClientSimCombatSystemHelper.CombatSetMaxHitpoints;
@@ -570,6 +579,16 @@ namespace VRC.SDK3.ClientSim
             VRCPlayerApi._UseLegacyLocomotion -= ClientSimPlayerManager.UseLegacyLocomotion;
             VRCPlayerApi._Respawn -= ClientSimPlayerManager.Respawn;
             VRCPlayerApi._RespawnWithIndex -= ClientSimPlayerManager.RespawnWithIndex;
+            
+            VRCPlayerApi._GetManualAvatarScalingAllowed -= ClientSimPlayerManager.GetManualAvatarScalingAllowed;
+            VRCPlayerApi._SetManualAvatarScalingAllowed -= ClientSimPlayerManager.SetManualAvatarScalingAllowed;
+            VRCPlayerApi._GetAvatarEyeHeightMinimumAsMeters -= ClientSimPlayerManager.GetAvatarEyeHeightMinimumAsMeters;
+            VRCPlayerApi._GetAvatarEyeHeightMaximumAsMeters -= ClientSimPlayerManager.GetAvatarEyeHeightMaximumAsMeters;
+            VRCPlayerApi._SetAvatarEyeHeightMinimumByMeters -= ClientSimPlayerManager.SetAvatarEyeHeightMinimumByMeters;
+            VRCPlayerApi._SetAvatarEyeHeightMaximumByMeters -= ClientSimPlayerManager.SetAvatarEyeHeightMaximumByMeters;
+            VRCPlayerApi._GetAvatarEyeHeightAsMeters -= ClientSimPlayerManager.GetAvatarEyeHeightAsMeters;
+            VRCPlayerApi._SetAvatarEyeHeightByMeters -= ClientSimPlayerManager.SetAvatarEyeHeightByMeters;
+            VRCPlayerApi._SetAvatarEyeHeightByMultiplier -= ClientSimPlayerManager.SetAvatarEyeHeightByMultiplier;
 
             VRCPlayerApi._CombatSetup -= ClientSimCombatSystemHelper.CombatSetup;
             VRCPlayerApi._CombatSetMaxHitpoints -= ClientSimCombatSystemHelper.CombatSetMaxHitpoints;

--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimPlayerManager.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimPlayerManager.cs
@@ -680,7 +680,6 @@ namespace VRC.SDK3.ClientSim
         
         private const float AVATAR_MIN_EYE_HEIGHT_DEFAULT = 0.2f;
         private const float AVATAR_MAX_EYE_HEIGHT_DEFAULT = 5f;
-        private const float AVATAR_EYE_HEIGHT_DEFAULT = 1.6f;
         
         public static bool GetManualAvatarScalingAllowed(VRCPlayerApi player)
         {

--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimPlayerManager.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimPlayerManager.cs
@@ -707,8 +707,7 @@ namespace VRC.SDK3.ClientSim
         
         public static float GetAvatarEyeHeightAsMeters(VRCPlayerApi arg)
         {
-            Debug.Log($"[ClientSim VRCPlayerApi.GetAvatarEyeHeightAsMeters] Returning default value of {AVATAR_EYE_HEIGHT_DEFAULT}.");
-            return AVATAR_EYE_HEIGHT_DEFAULT;
+            return ClientSimSettings.Instance.playerHeight;
         }
 
         public static void SetAvatarEyeHeightMinimumByMeters(VRCPlayerApi player, float value)

--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimPlayerManager.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimPlayerManager.cs
@@ -675,6 +675,63 @@ namespace VRC.SDK3.ClientSim
         }
 
         #endregion
+        
+        #region Player Scaling
+        
+        private const float AVATAR_MIN_EYE_HEIGHT_DEFAULT = 0.2f;
+        private const float AVATAR_MAX_EYE_HEIGHT_DEFAULT = 5f;
+        private const float AVATAR_EYE_HEIGHT_DEFAULT = 1.6f;
+        
+        public static bool GetManualAvatarScalingAllowed(VRCPlayerApi player)
+        {
+            Debug.Log($"[ClientSim VRCPlayerApi.GetManualAvatarScalingAllowed] Returning default value of true.");
+            return true;
+        }
+
+        public static void SetManualAvatarScalingAllowed(VRCPlayerApi player, bool value)
+        {
+            Debug.Log($"[ClientSim VRCPlayerApi.SetManualAvatarScalingAllowed] called with value {value}, doesn't do anything in ClientSim yet.");
+        }
+        
+        public static float GetAvatarEyeHeightMinimumAsMeters(VRCPlayerApi arg)
+        {
+            Debug.Log($"[ClientSim VRCPlayerApi.GetAvatarEyeHeightMinimumAsMeters] Returning default value of {AVATAR_MIN_EYE_HEIGHT_DEFAULT}.");
+            return AVATAR_MIN_EYE_HEIGHT_DEFAULT;
+        }
+
+        public static float GetAvatarEyeHeightMaximumAsMeters(VRCPlayerApi arg)
+        {
+            Debug.Log($"[ClientSim VRCPlayerApi.GetAvatarEyeHeightMaximumAsMeters] Returning default value of {AVATAR_MAX_EYE_HEIGHT_DEFAULT}.");
+            return AVATAR_MAX_EYE_HEIGHT_DEFAULT;
+        }
+        
+        public static float GetAvatarEyeHeightAsMeters(VRCPlayerApi arg)
+        {
+            Debug.Log($"[ClientSim VRCPlayerApi.GetAvatarEyeHeightAsMeters] Returning default value of {AVATAR_EYE_HEIGHT_DEFAULT}.");
+            return AVATAR_EYE_HEIGHT_DEFAULT;
+        }
+
+        public static void SetAvatarEyeHeightMinimumByMeters(VRCPlayerApi player, float value)
+        {
+            Debug.Log($"[ClientSim VRCPlayerApi.SetAvatarEyeHeightMinimumByMeters] called with value {value}, doesn't do anything in ClientSim yet.");
+        }
+
+        public static void SetAvatarEyeHeightMaximumByMeters(VRCPlayerApi player, float value)
+        {
+            Debug.Log($"[ClientSim VRCPlayerApi.SetAvatarEyeHeightMaximumByMeters] called with value {value}, doesn't do anything in ClientSim yet.");
+        }
+
+        public static void SetAvatarEyeHeightByMeters(VRCPlayerApi player, float value)
+        {
+            Debug.Log($"[ClientSim VRCPlayerApi.SetAvatarEyeHeightByMeters] called with value {value}, doesn't do anything in ClientSim yet.");
+        }
+
+        public static void SetAvatarEyeHeightByMultiplier(VRCPlayerApi player, float value)
+        {
+            Debug.Log($"[ClientSim VRCPlayerApi.SetAvatarEyeHeightByMultiplier] called with value {value}, doesn't do anything in ClientSim yet.");
+        }
+        
+        #endregion
     }
 }
  

--- a/Packages/com.vrchat.ClientSim/package.json
+++ b/Packages/com.vrchat.ClientSim/package.json
@@ -1,7 +1,7 @@
 {
 	"name" : "com.vrchat.clientsim",
 	"displayName" : "VRChat Client Simulator",
-	"version" : "1.2.6",
+	"version" : "1.2.7",
 	"unity" : "2019.4",
 	"description" : "VRChat Client Simulator for testing SDK3 worlds in Unity.",
 	"author" : {
@@ -14,7 +14,7 @@
 		"com.unity.inputsystem" : "1.2.0"
 	},
 	"vpmDependencies" : {
-		"com.vrchat.worlds" : "^3.1.x"
+		"com.vrchat.worlds" : "^3.2.2"
 	},
 	"samples" : [
 		{


### PR DESCRIPTION
Fixes NREs in SDK 3.2.2. Would be nice to actually Set and Get the values so Creators can test their logic in ClientSim, but this minimal implementation at least fixes the SDK so it doesn't show scary errors when you enter play mode.