### PR TITLE
Fix type mismatch during inital OnAvatarEyeHeightChanged call

### DIFF
--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimPlayerHeightManager.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimPlayerHeightManager.cs
@@ -45,7 +45,7 @@ namespace VRC.SDK3.ClientSim
             udonEventSender.RunEvent("_onAvatarChanged", ("player", joinEvent.player));
             udonEventSender.RunEvent("_onAvatarEyeHeightChanged",
                 ("player", joinEvent.player),
-                ("prevEyeHeightAsMeters", 0));
+                ("prevEyeHeightAsMeters", 0f));
         }
         
         public bool GetManualAvatarScalingAllowed() => manualScalingAllowed;


### PR DESCRIPTION
When a player joins, `OnAvatarEyeHeightChanged` is invoked with the `prevEyeHeightAsMeters` parameter passed as the literal integer 0, causing a type mismatch since it is expected to be a float.

The issue was brought to my attention by another user using one of my prefabs:
https://github.com/Nestorboy/NUMovement/issues/3