### PR TITLE
Fix Interaction Passthrough layers to match the client behavior

### DIFF
--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimInteractiveLayerProvider.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimInteractiveLayerProvider.cs
@@ -16,6 +16,7 @@ namespace VRC.SDK3.ClientSim
         private const int UI_LAYER = 5;
         private const int UI_MENU_LAYER = 12;
         private const int INTERNAL_UI_LAYER = 19;
+        private const int PLAYER_LOCAL_LAYER = 10;
         private const int MIRROR_REFLECTION_LAYER = 18;
         private const int FIRST_USER_LAYER = 22;
         
@@ -30,8 +31,8 @@ namespace VRC.SDK3.ClientSim
         {
             // Only the UI and UIMenu layers are interactable when the UI is open.
             _interactiveLayersUI = (1 << UI_LAYER) | (1 << UI_MENU_LAYER) | (1 << INTERNAL_UI_LAYER);
-            // When the menu is not open, all layers but UI, UIMenu, and MirrorReflection layers are interactable.
-            _interactiveLayersDefault = ~(1 << MIRROR_REFLECTION_LAYER) & ~_interactiveLayersUI;
+            // When the menu is not open, all layers but UI, UIMenu, PlayerLocal, and MirrorReflection layers are interactable.
+            _interactiveLayersDefault = ~(1 << UI_LAYER) & ~(1 << UI_MENU_LAYER) & ~(1 << PLAYER_LOCAL_LAYER) & ~(1 << MIRROR_REFLECTION_LAYER);
             // If Interaction Passthrough is set, these User Layers will also be ignored.
             _interactiveLayersDefault &= ~(VRC_SceneDescriptor.Instance.interactThruLayers << FIRST_USER_LAYER);
             

--- a/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimInteractiveLayerProvider.cs
+++ b/Packages/com.vrchat.ClientSim/Runtime/System/ClientSimInteractiveLayerProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEngine;
+using VRC.SDKBase;
 
 namespace VRC.SDK3.ClientSim
 {
@@ -16,6 +17,7 @@ namespace VRC.SDK3.ClientSim
         private const int UI_MENU_LAYER = 12;
         private const int INTERNAL_UI_LAYER = 19;
         private const int MIRROR_REFLECTION_LAYER = 18;
+        private const int FIRST_USER_LAYER = 22;
         
         private readonly int _interactiveLayersDefault;
         private readonly int _interactiveLayersUI;
@@ -30,6 +32,8 @@ namespace VRC.SDK3.ClientSim
             _interactiveLayersUI = (1 << UI_LAYER) | (1 << UI_MENU_LAYER) | (1 << INTERNAL_UI_LAYER);
             // When the menu is not open, all layers but UI, UIMenu, and MirrorReflection layers are interactable.
             _interactiveLayersDefault = ~(1 << MIRROR_REFLECTION_LAYER) & ~_interactiveLayersUI;
+            // If Interaction Passthrough is set, these User Layers will also be ignored.
+            _interactiveLayersDefault &= ~(VRC_SceneDescriptor.Instance.interactThruLayers << FIRST_USER_LAYER);
             
             _eventDispatcher = eventDispatcher;
             _eventDispatcher.Subscribe<ClientSimMenuStateChangedEvent>(SetMenuOpen);


### PR DESCRIPTION
The VRC Scene Descriptor has a property called "Interact Passthrough" that determines whether User Layers will block interaction rays. We have updated this setting to reflect changes in interaction behavior.
We have also revised the layer specifications to account for the built-in layers: PlayerLocal ignores rays, while InternalUI blocks interaction. Although these layer objects are unlikely to be used, we have confirmed that this change ensures the interaction behavior matches that of the VRChat client.
These behaviors are clearly stated in the VRChat documentation as well.
https://creators.vrchat.com/worlds/layers/