### PR TITLE
small failsafe for Decode()

### DIFF
--- a/Source/Runtime/Player/PlayerPersistence/ClientSimPlayerObjectStorage.cs
+++ b/Source/Runtime/Player/PlayerPersistence/ClientSimPlayerObjectStorage.cs
@@ -148,6 +148,7 @@ namespace VRC.SDK3.ClientSim.Persistence
             ClientSimPlayer player = _player.GetClientSimPlayer();
             foreach (GameObject persistantObject in player.PlayerPersistenceObjects)
             {
+                if (!persistantObject) continue;
                 IClientSimNetworkId networkId = persistantObject.GetComponent<IClientSimNetworkId>();
                 if (networkId == null) continue;
                 int id = networkId.GetNetworkId();


### PR DESCRIPTION
A small patch.

I was getting an error, similarly saying that some persistant objects are being destroyed but ClientSimPlayerObjectStorage's Decode function is trying to access on it.
Due to this error, the whole ClientSim seems to fail, making me impossible to test my world in Unity.

Even if it's an expected behaviour, I hope this small failsafe is applied to at least start the world test.