### PR TITLE
Fix to avoid setting Velocity on a Kinematic Rigidbody in ClientSimPositionSyncedHelperBase.cs

### DIFF
--- a/Source/Runtime/Helpers/ClientSimPositionSyncedHelperBase.cs
+++ b/Source/Runtime/Helpers/ClientSimPositionSyncedHelperBase.cs
@@ -82,7 +82,7 @@ namespace VRC.SDK3.ClientSim
             this.Log($"Respawning Object {Tools.GetGameObjectPath(gameObject)}");
             TeleportTo(_originalPosition, _originalRotation);
             
-            if (_rigidbody != null)
+            if (_rigidbody != null && !_rigidbody.isKinematic)
             {
                 _rigidbody.velocity = Vector3.zero;
             }


### PR DESCRIPTION
Fixes the following error:

Setting linear velocity of a kinematic body is not supported. UnityEngine.Rigidbody:set_velocity (UnityEngine.Vector3) VRC.SDK3.ClientSim.ClientSimPositionSyncedHelperBase:Respawn () (at ./Packages/com.vrchat.worlds/Integrations/ClientSim/Runtime/Helpers/ClientSimPositionSyncedHelperBase.cs:87) VRC.SDK3.ClientSim.ClientSimObjectSyncHelper:RespawnObject (VRC.SDK3.Components.VRCObjectSync) (at ./Packages/com.vrchat.worlds/Integrations/ClientSim/Runtime/Helpers/ClientSimObjectSyncHelper.cs:18) VRC.SDK3.Components.VRCObjectSync:Respawn ()
VRC.Udon.Wrapper.Modules.ExternVRCSDK3ComponentsVRCObjectSync:__Respawn__SystemVoid (VRC.Udon.Common.Interfaces.IUdonHeap,System.Span`1<uint>) VRC.Udon.VM.UdonVM:Interpret ()
VRC.Udon.UdonBehaviour:RunProgram (uint) (at ./Packages/com.vrchat.worlds/Runtime/Udon/UdonBehaviour.cs:1156) VRC.Udon.UdonBehaviour:RunProgram (string) (at ./Packages/com.vrchat.worlds/Runtime/Udon/UdonBehaviour.cs:1130) VRC.Udon.UdonBehaviour:SendCustomEvent (string) (at ./Packages/com.vrchat.worlds/Runtime/Udon/UdonBehaviour.cs:2082) VRC.Udon.ClientBindings.UdonEventScheduler:ProcessTimeEvents (VRC.Udon.Common.Enums.EventTiming) VRC.Udon.ClientBindings.UdonEventScheduler:RunScheduledEvents (VRC.Udon.Common.Enums.EventTiming) VRC.Udon.UdonManager:Update () (at ./Packages/com.vrchat.worlds/Runtime/Udon/UdonManager.cs:454)